### PR TITLE
Gemspec no worky with Rails 3.1.0

### DIFF
--- a/rails_config.gemspec
+++ b/rails_config.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files       = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables      = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 
-  s.add_runtime_dependency "activesupport", "~> 3.0"
+  s.add_runtime_dependency "activesupport", ">= 3.0"
   s.add_development_dependency "rspec", "~> 2.0"
   s.add_development_dependency "autotest", ">= 0"
   s.add_development_dependency "growl-glue", ">= 0"


### PR DESCRIPTION
Gemspec no worky with Rails 3.1.0 as you are using tilde's (the "~" character), so I replaced them with ">="
