### PR TITLE
Allow more options to be dynamically merged in at runtime.

### DIFF
--- a/lib/rails_config/options.rb
+++ b/lib/rails_config/options.rb
@@ -53,6 +53,13 @@ module RailsConfig
       to_hash.to_json(*args)
     end
 
+    def merge!(hash)
+      current = to_hash
+      DeepMerge.deep_merge!(current, hash.dup)
+      marshal_load(__convert(hash).marshal_dump)
+      self
+    end
+    
     protected
 
     # Recursively converts Hashes to Options (including Hashes inside Arrays)

--- a/spec/rails_config_spec.rb
+++ b/spec/rails_config_spec.rb
@@ -154,4 +154,21 @@ describe RailsConfig do
     end
   end
 
+  context "Merging hash at runtime" do
+    let(:config) { RailsConfig.load_files(setting_path("settings.yml")) }
+    let(:hash) { {:options => {:suboption => 'value'}} }
+    
+    it 'should be chainable' do
+      config.merge!({}).should === config
+    end
+    
+    it 'should preserve existing keys' do
+      expect { config.merge!({}) }.to_not change{ config.keys }
+    end
+    
+    it 'should recursively merge keys' do
+      config.merge!(hash)
+      config.options.suboption.should == 'value'
+    end
+  end
 end


### PR DESCRIPTION
We've got a case where it's difficult to load certain auth settings from the yaml files. We normally merge these in at runtime after decrypting them so I've extended the Options object to allow this.
