### PR TITLE
A modest proposal to enhance RailsConfig::Options

### DIFF
--- a/lib/rails_config/options.rb
+++ b/lib/rails_config/options.rb
@@ -59,6 +59,14 @@ module RailsConfig
       marshal_load(__convert(hash).marshal_dump)
       self
     end
+
+    def [](param)
+      send("#{param}")
+    end
+
+    def []=(param, value)
+      send("#{param}=", value)
+    end
     
     protected
 

--- a/spec/rails_config_spec.rb
+++ b/spec/rails_config_spec.rb
@@ -171,4 +171,22 @@ describe RailsConfig do
       config.options.suboption.should == 'value'
     end
   end
+
+  context "[] accessors" do
+    let(:config) do
+      files = [setting_path("development.yml")]
+      RailsConfig.load_files(files)
+    end
+
+    it "should access attributes using []" do
+      config.section['size'].should == 3
+      config.section[:size].should == 3
+      config[:section][:size].should == 3
+    end
+
+    it "should set values using []=" do
+      config.section[:foo] = 'bar'
+      config.section.foo.should == 'bar'
+    end
+  end
 end


### PR DESCRIPTION
This implements the ability to use [] operators to access properties.  This lets you readily access a setting without necessarily knowing which setting you'll need ahead of time.  For example:

  config.section['size]
  config.section[:size]
  config[:section][:size]
  config.section.size

all return the same value.  You can achieve a similar result by using a hash type, but I think this is a more flexible, intuitive approach.
