### PR TITLE
Fix closing ' in example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Alternatively, you can also use the `[]` operator if you don't know which exact 
 ```ruby
 # All the following are equivalent to Settings.my_section.some_entry
 Settings.my_section[:some_entry]
-Settings.my_section['some_entry]
+Settings.my_section['some_entry']
 Settings[:my_section][:some_entry]
 ```
 


### PR DESCRIPTION
Just a typo fix in the README.
