### PR TITLE
add_development_dependency "rdoc" for Ruby 1.8

### DIFF
--- a/rails_config.gemspec
+++ b/rails_config.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "activesupport", ">= 3.0"
   s.add_development_dependency "rake"
+  s.add_development_dependency "rdoc"
   s.add_development_dependency "rspec", "~> 2.0"
   s.add_development_dependency "autotest", ">= 0"
   s.add_development_dependency "growl-glue", ">= 0"


### PR DESCRIPTION
We need "rdoc" in the development dependencies with Ruby 1.8
