### PR TITLE
Define each to RailsConfig::Options to mixin Enumerable

### DIFF
--- a/lib/rails_config/options.rb
+++ b/lib/rails_config/options.rb
@@ -2,6 +2,8 @@ require 'ostruct'
 module RailsConfig
   class Options < OpenStruct
 
+    include Enumerable
+
     def empty?
       marshal_dump.empty?
     end
@@ -46,6 +48,10 @@ module RailsConfig
         result[k] = v.instance_of?(RailsConfig::Options) ? v.to_hash : v
       end
       result
+    end
+
+    def each(*args, &block)
+      marshal_dump.each(*args, &block)
     end
 
     def to_json(*args)

--- a/spec/rails_config_spec.rb
+++ b/spec/rails_config_spec.rb
@@ -215,4 +215,27 @@ describe RailsConfig do
       config.section.foo.should eq 'bar'
     end
   end
+
+  context "enumerable" do
+    let(:config) do
+      files = [setting_path("development.yml")]
+      RailsConfig.load_files(files)
+    end
+
+    it "should enumerate top level parameters" do
+      keys = []
+      config.each { |key, value| keys << key }
+      keys.should eq [:size, :section]
+    end
+
+    it "should enumerate inner parameters" do
+      keys = []
+      config.section.each { |key, value| keys << key }
+      keys.should eq [:size, :servers]
+    end
+
+    it "should have methods defined by Enumerable" do
+      config.map { |key, value| key }.should eq [:size, :section]
+    end
+  end
 end


### PR DESCRIPTION
When I use config like key-value pairs, I want to enumerate them.

The only way to do this was `to_hash.each`, but this is ugly and can be heavy process.

I want to directly use `each` and other Enumerable methods.
