### PR TITLE
Attempt to fix usage in application.rb

### DIFF
--- a/lib/rails_config/integration/rails.rb
+++ b/lib/rails_config/integration/rails.rb
@@ -3,28 +3,25 @@ module RailsConfig
     module Rails3
       if defined?(Rails::Railtie)
         class Railtie < Rails::Railtie
-
-          initializer "rails_config" do
-            ActiveSupport.on_load :before_configuration, :yield => true do
-              initializer = Rails.root.join("config", "initializers", "rails_config.rb")
-              require initializer if File.exist?(initializer)
+          ActiveSupport.on_load :before_configuration, :yield => true do
+            initializer = Rails.root.join("config", "initializers", "rails_config.rb")
+            require initializer if File.exist?(initializer)
 
 
-              RailsConfig.load_and_set_settings(
-                Rails.root.join("config", "settings.yml").to_s,
-                Rails.root.join("config", "settings", "#{Rails.env}.yml").to_s,
-                Rails.root.join("config", "environments", "#{Rails.env}.yml").to_s,
+            RailsConfig.load_and_set_settings(
+              Rails.root.join("config", "settings.yml").to_s,
+              Rails.root.join("config", "settings", "#{Rails.env}.yml").to_s,
+              Rails.root.join("config", "environments", "#{Rails.env}.yml").to_s,
 
-                Rails.root.join("config", "settings.local.yml").to_s,
-                Rails.root.join("config", "settings", "#{Rails.env}.local.yml").to_s,
-                Rails.root.join("config", "environments", "#{Rails.env}.local.yml").to_s
-              )
+              Rails.root.join("config", "settings.local.yml").to_s,
+              Rails.root.join("config", "settings", "#{Rails.env}.local.yml").to_s,
+              Rails.root.join("config", "environments", "#{Rails.env}.local.yml").to_s
+            )
               
               # Rails Dev environment should reload the Settings on every request
-              if Rails.env.development?
-                ActionController::Base.class_eval do
-                  prepend_before_filter { ::RailsConfig.reload! }
-                end
+            if Rails.env.development?
+              ActionController::Base.class_eval do
+                prepend_before_filter { ::RailsConfig.reload! }
               end
             end
           end


### PR DESCRIPTION
I fixed usage in `application.rb` (#32, #44), by reverting a change. **But** I broke some features in the process (changing the constant) by hooking directly into ActiveSupport.

Does anyone have any ideas how I could hook in earlier (before `application.rb` is loaded), but preserve the initializer order (loading after `:load_custom_rails_config`).

/cc @railsjedi
