### PR TITLE
Add a shortcut method for setting files.

### DIFF
--- a/lib/rails_config.rb
+++ b/lib/rails_config.rb
@@ -37,6 +37,18 @@ module RailsConfig
     Kernel.const_set(RailsConfig.const_name, RailsConfig.load_files(files))
   end
 
+  def self.setting_files(config_root, env)
+    [
+      File.join(config_root, "settings.yml").to_s,
+      File.join(config_root, "settings", "#{env}.yml").to_s,
+      File.join(config_root, "environments", "#{env}.yml").to_s,
+
+      File.join(config_root, "settings.local.yml").to_s,
+      File.join(config_root, "settings", "#{env}.local.yml").to_s,
+      File.join(config_root, "environments", "#{env}.local.yml").to_s
+    ].freeze
+  end
+
   def self.reload!
     Kernel.const_get(RailsConfig.const_name).reload!
   end

--- a/lib/rails_config/integration/rails.rb
+++ b/lib/rails_config/integration/rails.rb
@@ -12,15 +12,7 @@ module RailsConfig
 
           # Parse the settings before any of the initializers
           initializer :load_rails_config_settings, :after => :load_custom_rails_config, :before => :load_environment_config, :group => :all do
-            RailsConfig.load_and_set_settings(
-              Rails.root.join("config", "settings.yml").to_s,
-              Rails.root.join("config", "settings", "#{Rails.env}.yml").to_s,
-              Rails.root.join("config", "environments", "#{Rails.env}.yml").to_s,
-
-              Rails.root.join("config", "settings.local.yml").to_s,
-              Rails.root.join("config", "settings", "#{Rails.env}.local.yml").to_s,
-              Rails.root.join("config", "environments", "#{Rails.env}.local.yml").to_s
-            )
+            RailsConfig.load_and_set_settings(RailsConfig.setting_files(Rails.root.join("config"), Rails.env))
           end
 
           # Rails Dev environment should reload the Settings on every request

--- a/lib/rails_config/integration/sinatra.rb
+++ b/lib/rails_config/integration/sinatra.rb
@@ -18,15 +18,7 @@ module RailsConfig
         root = Padrino.root
       end
 
-      RailsConfig.load_and_set_settings(
-        File.join(root.to_s, "config", "settings.yml").to_s,
-        File.join(root.to_s, "config", "settings", "#{env}.yml").to_s,
-        File.join(root.to_s, "config", "environments", "#{env}.yml").to_s,
-
-        File.join(root.to_s, "config", "settings.local.yml").to_s,
-        File.join(root.to_s, "config", "settings", "#{env}.local.yml").to_s,
-        File.join(root.to_s, "config", "environments", "#{env}.local.yml").to_s
-      )
+      RailsConfig.load_and_set_settings(RailsConfig.setting_files(File.join(root, 'config'), env))
 
       inner_app.use(::RailsConfig::Rack::Reloader) if inner_app.development?
     end

--- a/spec/rails_config_spec.rb
+++ b/spec/rails_config_spec.rb
@@ -1,6 +1,17 @@
 require 'spec_helper'
 
 describe RailsConfig do
+  it "should get setting files" do
+    config = RailsConfig.setting_files("root/config", "test")
+    config.should eq [
+      'root/config/settings.yml',
+      'root/config/settings/test.yml',
+      'root/config/environments/test.yml',
+      'root/config/settings.local.yml',
+      'root/config/settings/test.local.yml',
+      'root/config/environments/test.local.yml'
+    ]
+  end
 
   it "should load a basic config file" do
     config = RailsConfig.load_files(setting_path("settings.yml"))


### PR DESCRIPTION
Hi there,

I think it's great if rails_config provide setting file paths because I want to use it for rake task and unicorn.
For example, in my `config/unicorn.rb`

``` ruby
RailsConfig.load_and_set_settings(RailsConfig.setting_files(File.expand_path("../", __FILE__), ENV['RAILS_ENV'] || 'development'))
```

What do you think?
