### PR TITLE
Passing App Argument to Rake Task

### DIFF
--- a/lib/rails_config/tasks/heroku.rake
+++ b/lib/rails_config/tasks/heroku.rake
@@ -1,7 +1,7 @@
 require 'rails_config'
 require 'tasks.rb'
 namespace 'rails_config' do
-  task :heroku => :environment do |_, args|
+  task :heroku, [:app] => :environment do |_, args|
     RailsConfig::Tasks::Heroku.new(args[:app]).invoke
   end
 end


### PR DESCRIPTION
Passing the `:app` argument to the `rake rails_config:heroku` rake tasks requires that the argument is specified in the rake task. (See http://robots.thoughtbot.com/how-to-use-arguments-in-a-rake-task) I've added that here. Now, you can specify the app name when calling the rake task:
`bundle exec rake rails_config:heroku\[myapp\]`
This should probably also be added to the `README`, but that's your decision to make, so I didn't include it in this pull request.
