### PR TITLE
Enable Loading Environment Varibles to Boolean and Integer 

### DIFF
--- a/lib/rails_config/options.rb
+++ b/lib/rails_config/options.rb
@@ -21,7 +21,7 @@ module RailsConfig
       conf = Hash.new
       ENV.each do |key, value|
         next unless key.to_s.index(RailsConfig.const_name) == 0
-        hash = value
+        hash = try_to_convert(value)
         key.to_s.split('.').reverse.each do |element|
           hash = {element => hash}
         end
@@ -114,6 +114,17 @@ module RailsConfig
         s.send("#{k}=".to_sym, v)
       end
       s
+    end
+
+    def try_to_convert(str)
+      case str
+      when 'true' then true
+      when 'false' then false
+      else
+        Integer(str, 10)
+      end
+    rescue ArgumentError, TypeError
+      str
     end
   end
 end


### PR DESCRIPTION
I'm aware that you may consider this a controversial feature, and I would understand if you wanted to keep it straightforward and simpler and just load strings from the environment when using it for settings. However, this eliminates the need to use something like `eval()` around boolean configuration settings stored as strings, as well as `to_i` on settings stored as Integers.

As far as the actual code, I did some research and the way I convert to Integer makes the most sense to me. Although it seems a bit messy to use exceptions in this way, it is the only way to accurately check if the input string is considered by ruby to be a valid integer; `.to_i` on a String is completely tolerant of errors and other information, and any regex matching would be duplicating functionality that the language already implements and would never be as tolerant of things such as underscores and other characters that ruby allows in integers (whereas this method is). See the second answer to this question:
http://stackoverflow.com/questions/1235863/test-if-a-string-is-basically-an-integer-in-quotes-using-ruby
for more on it.
