### PR TITLE
Support returning keys for options

### DIFF
--- a/lib/rails_config/options.rb
+++ b/lib/rails_config/options.rb
@@ -4,9 +4,8 @@ module RailsConfig
 
     include Enumerable
 
-    def empty?
-      marshal_dump.empty?
-    end
+    delegate :keys,   to: :marshal_dump
+    delegate :empty?, to: :marshal_dump
 
     def add_source!(source)
       # handle yaml file paths

--- a/spec/rails_config_spec.rb
+++ b/spec/rails_config_spec.rb
@@ -282,4 +282,19 @@ describe RailsConfig do
       config.map { |key, value| key }.should eq [:size, :section]
     end
   end
+
+  context "keys" do
+    let(:config) do
+      files = ["#{fixture_path}/development.yml"]
+      RailsConfig.load_files(files)
+    end
+
+    it "should return array of keys" do
+      config.keys.should include(:size, :section)
+    end
+
+    it "should return array of keys for nested entry" do
+      config.section.keys.should include(:size, :servers)
+    end
+  end
 end


### PR DESCRIPTION
Current behavior:
Executing `Settings.somethings.keys` returns `nil`

Expected behavior:
Returns array of keys for particular entry.
