### PR TITLE
fix deprecation warning on File.exists?

### DIFF
--- a/lib/rails_config/sources/yaml_source.rb
+++ b/lib/rails_config/sources/yaml_source.rb
@@ -13,7 +13,7 @@ module RailsConfig
 
       # returns a config hash from the YML file
       def load
-        if @path and File.exists?(@path.to_s)
+        if @path and File.exist?(@path.to_s)
           result = YAML.load(ERB.new(IO.read(@path.to_s)).result)
         end
         result || {}


### PR DESCRIPTION
fix deprecation warning on File.exists?
