### PR TITLE
Fix generate error when .gitignore is missing.

### DIFF
--- a/lib/generators/rails_config/install_generator.rb
+++ b/lib/generators/rails_config/install_generator.rb
@@ -18,6 +18,8 @@ module RailsConfig
       end
 
       def modify_gitignore
+        create_file '.gitignore' unless File.exists? '.gitignore'
+
         append_to_file '.gitignore' do
           "\n"                                +
           "config/settings.local.yml\n"       +


### PR DESCRIPTION
The Rails generator errors out when there is to .gitignore file.
This creates it if it's missing.

Fixes #35
