### PR TITLE
make rails_config work without rails

### DIFF
--- a/lib/rails_config.rb
+++ b/lib/rails_config.rb
@@ -2,7 +2,7 @@ require 'active_support/core_ext/module/attribute_accessors'
 
 require 'rails_config/options'
 require 'rails_config/version'
-require 'rails_config/engine'
+require 'rails_config/engine' if defined?(::Rails)
 require 'rails_config/sources/yaml_source'
 require 'rails_config/vendor/deep_merge' unless defined?(DeepMerge)
 


### PR DESCRIPTION
I know it's called rails_config. But since it doesn't need rails it would still be nice if it worked without it, too. And clearly this is intended anyway as you can see when you look further down in [`rails_config.rb`](https://github.com/railsconfig/rails_config/blob/master/lib/rails_config.rb#L49).

Anyway requiring [`engine.rb`](https://github.com/railsconfig/rails_config/blob/master/lib/rails_config/engine.rb) makes Rails a hard, implicit dependency. So it should only be done if Rails is actually present.
