### PR TITLE
Add method prepend_source!

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,16 @@ Settings.reload!
 
 This will use the given source.yml file and use its settings to overwrite any previous ones.
 
+On the other hand, you can prepend a YML file to the list of configuration files:
+
+```ruby
+Settings.prepend_source!("/path/to/source.yml")
+Settings.reload!
+```
+
+This will do the same as `add_source`, but the given YML file will be loaded first (instead of last) and its settings will be overwritten by any other configuration file.
+This is especially useful if you want to define defaults.
+
 One thing I like to do for my Rails projects is provide a local.yml config file that is .gitignored (so its independent per developer). Then I create a new initializer in `config/initializers/add_local_config.rb` with the contents
 
 ```ruby

--- a/lib/rails_config/options.rb
+++ b/lib/rails_config/options.rb
@@ -19,6 +19,13 @@ module RailsConfig
       @config_sources << source
     end
 
+    def prepend_source!(source)
+      source = (Sources::YAMLSource.new(source)) if source.is_a?(String)
+
+      @config_sources ||= []
+      @config_sources.unshift(source)
+    end
+
     def reload_env!
       return self if ENV.nil? || ENV.empty?
       conf = Hash.new

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -21,4 +21,64 @@ describe RailsConfig::Options do
     end
   end
 
+  context 'adding sources' do
+    let(:config) do
+      RailsConfig.load_files("#{fixture_path}/settings.yml")
+    end
+
+    before do
+      config.add_source!("#{fixture_path}/deep_merge2/config1.yml")
+      config.reload!
+    end
+
+    it 'should still have the initial config' do
+      expect(config['size']).to eq(1)
+    end
+
+    it 'should add keys from the added file' do
+      expect(config['tvrage']['service_url']).to eq('http://services.tvrage.com')
+    end
+
+    context 'overwrite' do
+      before do
+        config.add_source!("#{fixture_path}/deep_merge2/config2.yml")
+        config.reload!
+      end
+
+      it 'should overwrite the previous values' do
+        expect(config['tvrage']['service_url']).to eq('http://url2')
+      end
+    end
+  end
+
+  context 'prepending sources' do
+    let(:config) do
+      RailsConfig.load_files("#{fixture_path}/settings.yml")
+    end
+
+    before do
+      config.prepend_source!("#{fixture_path}/deep_merge2/config1.yml")
+      config.reload!
+    end
+
+    it 'should still have the initial config' do
+      expect(config['size']).to eq(1)
+    end
+
+    it 'should add keys from the added file' do
+      expect(config['tvrage']['service_url']).to eq('http://services.tvrage.com')
+    end
+
+    context 'be overwriten' do
+      before do
+        config.prepend_source!("#{fixture_path}/deep_merge2/config2.yml")
+        config.reload!
+      end
+
+      it 'should overwrite the previous values' do
+        expect(config['tvrage']['service_url']).to eq('http://services.tvrage.com')
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Sometimes you want to have custom configuration files that are loaded
before the default files, in order to let the `*.local.*` files
overwrite those settings. This method enables this behaviour.