### PR TITLE
Add the overwrite_arrays option

### DIFF
--- a/lib/rails_config.rb
+++ b/lib/rails_config.rb
@@ -10,9 +10,10 @@ module RailsConfig
   # ensures the setup only gets run once
   @@_ran_once = false
 
-  mattr_accessor :const_name, :use_env
+  mattr_accessor :const_name, :use_env, :overwrite_arrays
   @@const_name = "Settings"
   @@use_env = false
+  @@overwrite_arrays = false
 
   def self.setup
     yield self if @@_ran_once == false

--- a/lib/rails_config/options.rb
+++ b/lib/rails_config/options.rb
@@ -23,7 +23,7 @@ module RailsConfig
         key.to_s.split('.').reverse.each do |element|
           hash = {element => hash}
         end
-        DeepMerge.deep_merge!(hash, conf, :preserve_unmergeables => false)
+        DeepMerge.deep_merge!(hash, conf, :preserve_unmergeables => false, :overwrite_arrays => RailsConfig.overwrite_arrays)
       end
 
       merge!(conf[RailsConfig.const_name] || {})
@@ -40,7 +40,7 @@ module RailsConfig
         if conf.empty?
           conf = source_conf
         else
-          DeepMerge.deep_merge!(source_conf, conf, :preserve_unmergeables => false)
+          DeepMerge.deep_merge!(source_conf, conf, :preserve_unmergeables => false, :overwrite_arrays => RailsConfig.overwrite_arrays)
         end
       end
 
@@ -78,7 +78,7 @@ module RailsConfig
 
     def merge!(hash)
       current = to_hash
-      DeepMerge.deep_merge!(hash.dup, current)
+      DeepMerge.deep_merge!(hash.dup, current, :overwrite_arrays => RailsConfig.overwrite_arrays)
       marshal_load(__convert(current).marshal_dump)
       self
     end


### PR DESCRIPTION
I think we should be able to diable merging arrays.

e.g. Let's say you have the default settings like below.

`config/settings.yml`
```yaml
email:
  recipients:
    - foo1@example.com
    - foo2@example.com
```

And for production settings.

`config/settings/production.yml`
```yaml
email:
  recipients:
    - bar@example.com
```

`RailsConfig` merges the settings like below.

```yaml
email:
  recipients:
    - foo1@example.com
    - foo2@example.com
    - bar@example.com
```

However, I don't want to send email to `foo1@example.com` and `foo2@example.com` in production. Currently, we don't have any method to achieve this goal. So I just added an option to disable merging arrays.

What do you think this idea?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/railsconfig/rails_config/103)
<!-- Reviewable:end -->
