### PR TITLE
Additional options for parsing env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,12 +263,9 @@ Inheritance customization (check [Deep Merge](https://github.com/danielsdeleo/de
 
 * `knockout_prefix` - ability to remove elements of the array set in earlier loaded settings file. Default: `nil`
 
+## Environment variables
 
-## Working with Heroku
-
-Heroku uses ENV object to store sensitive settings which are like the local files described above. You cannot upload such files to Heroku because it's ephemeral filesystem gets recreated from the git sources on each instance refresh.
-
-To use config with Heroku just set the `use_env` var to `true` in your `config/initializers/config.rb` file. Eg:
+To load environment variables from the `ENV` object, that will override any settings defined in files, set the `use_env` to true in your `config/initializers/config.rb` file. Eg:
 
 ```ruby
 Config.setup do |config|
@@ -286,7 +283,41 @@ ENV['AppSettings.section.server'] = 'google.com'
 
 It won't work with arrays, though.
 
+### Working with Heroku
+
+Heroku uses ENV object to store sensitive settings. You cannot upload such files to Heroku because it's ephemeral filesystem gets recreated from the git sources on each instance refresh. To use config with Heroku just set the `use_env` var to `true` as mentioned above.
+
 To upload your local values to Heroku you could ran `bundle exec rake config:heroku`.
+
+### Fine-tuning
+
+You can config how the environment variables will be processed, in case you want to specify variables in ALL CAPS, using double underscores instead of dots for separators, or parse numeric values as integers instead of strings.
+
+For instance, given the following environment:
+
+```bash
+APP__SECTION__SERVER_SIZE=1
+APP__SECTION__SERVER=google.com
+```
+
+And the following configuration:
+
+```ruby
+Config.setup do |config|
+  config.use_env = true
+  config.env_prefix = "APP"
+  config.env_separator = '__'
+  config.env_converter = :downcase
+  config.env_parse_values = true
+end
+```
+
+The following settings will be available:
+
+```ruby
+Settings.section.server_size # => 1
+Settings.section.server # => 'google.com'
+```
 
 ## Contributing
 

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -11,9 +11,13 @@ module Config
   # Ensures the setup only gets run once
   @@_ran_once = false
 
-  mattr_accessor :const_name, :use_env
+  mattr_accessor :const_name, :use_env, :env_prefix, :env_separator, :env_converter, :env_parse_values
   @@const_name = "Settings"
   @@use_env    = false
+  @@env_prefix = nil
+  @@env_separator = "."
+  @@env_converter = nil
+  @@env_parse_values = false
 
   # deep_merge options
   mattr_accessor :knockout_prefix

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -104,14 +104,64 @@ describe Config do
       Config.use_env = false
     end
 
+    after :each do
+      Config.env_prefix = nil
+      Config.env_separator = "."
+      Config.env_converter = nil
+      Config.env_parse_values = false
+    end
+
     it "should load basic ENV variables" do
       config.load_env!
       expect(config.test_var).to eq("123")
     end
 
+    it "should parse ENV variables as numeric" do
+      Config.env_parse_values = true
+      config.load_env!
+      expect(config.test_var).to eq(123)
+    end
+
+    it "should leave ENV variables as strings" do
+      Config.env_parse_values = true
+      config.load_env!
+      expect(config.test_str_var).to eq("foobar")
+    end
+
     it "should load nested sections" do
       config.load_env!
       expect(config.hash_test.one).to eq("1-1")
+    end
+
+    it "should use env specific prefix" do
+      ENV['MyConfig.hash_test.three'] = "1-3"
+      Config.env_prefix = "MyConfig"
+      config.load_env!
+      expect(config.hash_test.one).to be_nil
+      expect(config.hash_test.three).to eq("1-3")
+    end
+
+    it "should use env specific separator" do
+      ENV['Settings__hash_test__four'] = "1-4"
+      Config.env_separator = "__"
+      config.load_env!
+      expect(config.hash_test.four).to eq("1-4")
+    end
+
+    it "should convert env keys to downcase" do
+      ENV['Settings.HASH_TEST.FIVE'] = "1-5"
+      Config.env_converter = :downcase
+      config.load_env!
+      expect(config.hash_test.five).to eq("1-5")
+    end
+
+    it "should parse env-like keys" do
+      ENV['APP__HASH_TEST__SIX'] = "1-6"
+      Config.env_converter = :downcase
+      Config.env_prefix = "APP"
+      Config.env_separator = "__"
+      config.load_env!
+      expect(config.hash_test.six).to eq("1-6")
     end
 
     it "should override settings from files" do

--- a/spec/fixtures/env/settings.yml
+++ b/spec/fixtures/env/settings.yml
@@ -1,4 +1,5 @@
 Settings.test_var: 123
+Settings.test_str_var: foobar
 Settings.size: 3
 Settings.hash_test.one: 1-1
 Settings.hash_test.two: 1-2


### PR DESCRIPTION
Allows setting env vars like "SETTINGS__FOLDER__MY_KEY".

- env_prefix: change the prefix for the env vars to be processed
- env_separator: set the symbol or symbols on which to split
- env_converter: set to :downcase to change MY_KEY to my_key
- env_parse_values: convert integer-like env values to integers

This is similar to https://github.com/railsconfig/config/pull/119/, but builds on the existing `env_load!` method and provides further customisation on the format of the env variables. It should fix https://github.com/railsconfig/config/issues/108.