### PR TITLE
Add gem name in Installation Instruction section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For older versions of Rails or Ruby use [AppConfig](http://github.com/fredwu/app
 
 ### Installing on Rails 3 or 4
 
-Add the gem to your `Gemfile` and run `bundle install` to install it. Then run
+Add `gem 'config'` to your `Gemfile` and run `bundle install` to install it. Then run
 
     rails g config:install
 


### PR DESCRIPTION
Since there's no gem name in the documentation, especially in Installation section.

This also will help people who used this gem in the past (gem name back then was `rails-config`) in order to clear the confusion.