### PR TITLE
Merging environment variables should not override existing settings

### DIFF
--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -107,7 +107,8 @@ module Config
 
     def merge!(hash)
       current = to_hash
-      DeepMerge.deep_merge!(hash.dup, current)
+      hash = Config::Options.new(hash.dup).to_hash
+      DeepMerge.deep_merge!(hash, current)
       marshal_load(__convert(current).marshal_dump)
       self
     end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -178,6 +178,14 @@ describe Config do
       expect(Settings.server).to eq("google.com")
       expect(Settings.size).to eq("3")
     end
+
+    it "should deep merge hashes" do
+      ENV['Settings.inner.something1'] = 'new blah'
+      config = Config.load_files("#{fixture_path}/deep_merge/config1.yml")
+
+      expect(config.inner.something1).to eq('new blah')
+      expect(config.inner.something2).to eq('blah2')
+    end
   end
 
   context "Nested Settings" do


### PR DESCRIPTION
We're having a problem with the new environment loading code and our configuration hierarchy.

With a setting like:

```yaml
feature:
  enabled: true
  group: x
```

If I have an environment variable (and config configuration to support..)  e.g. `SETTINGS_FEATURE_GROUP=y`, in the application I see: 

```ruby
Settings.feature.group # => 'y'
```

But, other keys in the configuration are removed:

```ruby
Settings.feature.enabled # => nil
```

It looks like there's a problem with string + symbol hashes coming out of `OpenStruct`. I don't know if we ought to assume OpenStruct will always dump symbolized hashes, or, as I do here, push the hash through `Config::Options` before dumping it.

