### PR TITLE
Typo fix for Config::Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ module Appname
   class Application < Rails::Application
 
     Bundler.require(*Rails.groups)
-    Config::Integration::Rails::Railtie.preload
+    Config::Integrations::Rails::Railtie.preload
 
     # ...
 


### PR DESCRIPTION
The README is incorrect and needs to be updated. RE: #145 