### PR TITLE
Overwrite arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ application initialization phase:
 Config.setup do |config|
   config.const_name = 'Settings'
   ...
+  config.knockout_prefix = nil
+  config.overwrite_arrays = false
 end
 ```
 
@@ -274,6 +276,8 @@ located at `config/initializers/config.rb`.
 * `knockout_prefix` - ability to remove elements of the array set in earlier loaded settings file. Default: `nil`
 
 Check [Deep Merge](https://github.com/danielsdeleo/deep_merge) for more details.
+
+* `overwrite_arrays` - ability to replace an entire array set in earlier loaded settings file. Default: `false`
 
 ### Environment variables
 

--- a/config.gemspec
+++ b/config.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |s|
   s.require_paths         = ['lib']
   s.required_ruby_version = '>= 2.0.0'
 
-  s.add_dependency 'activesupport',           '>= 3.0'
-  s.add_dependency 'deep_merge',              '~> 1.0',   '>= 1.0.1'
+  s.add_dependency "activesupport",           ">= 3.0"
+  s.add_dependency "deep_merge2",              "~> 1.0"
 
   s.add_development_dependency 'bundler',     '~> 1.11',  '>= 1.11.2'
   s.add_development_dependency 'rake',        '~> 11.1',  '>= 11.1.2'

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -20,8 +20,9 @@ module Config
   @@env_parse_values = true
 
   # deep_merge options
-  mattr_accessor :knockout_prefix
+  mattr_accessor :knockout_prefix, :overwrite_arrays
   @@knockout_prefix = nil
+  @@overwrite_arrays = false
 
   def self.setup
     yield self if @@_ran_once == false

--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -72,7 +72,6 @@ module Config
           DeepMerge.deep_merge!(source_conf,
                                 conf,
                                 preserve_unmergeables: false,
-                                knockout_prefix:       Config.knockout_prefix)
                                 knockout_prefix: Config.knockout_prefix,
                                 overwrite_arrays: Config.overwrite_arrays)
         end

--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -73,6 +73,8 @@ module Config
                                 conf,
                                 preserve_unmergeables: false,
                                 knockout_prefix:       Config.knockout_prefix)
+                                knockout_prefix: Config.knockout_prefix,
+                                overwrite_arrays: Config.overwrite_arrays)
         end
       end
 
@@ -116,7 +118,10 @@ module Config
 
     def merge!(hash)
       current = to_hash
-      DeepMerge.deep_merge!(hash.dup, current)
+      DeepMerge.deep_merge!(hash.dup,
+                            current,
+                            preserve_unmergeables: false,
+                            overwrite_arrays: Config.overwrite_arrays)
       marshal_load(__convert(current).marshal_dump)
       self
     end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -320,5 +320,37 @@ describe Config do
         end
       end
     end
+
+    context 'using overwrite_arrays' do
+      context 'in configuration phase' do
+        it 'should be able to assign a different overwrite_arrays value' do
+          Config.reset
+          Config.overwrite_arrays = true
+
+          expect(Config.overwrite_arrays).to eq(true)
+        end
+
+        it 'should have the default overwrite_arrays value equal false' do
+          Config.reset
+
+          expect(Config.overwrite_arrays).to eq(false)
+        end
+      end
+
+      context 'overwriting' do
+        let(:config) do
+          Config.overwrite_arrays = true
+          Config.load_files(["#{fixture_path}/overwrite_arrays/config1.yml",
+                             "#{fixture_path}/overwrite_arrays/config2.yml",
+                             "#{fixture_path}/overwrite_arrays/config3.yml"])
+        end
+
+        it 'should remove elements from settings' do
+          expect(config.array1).to eq(['item4', 'item5', 'item6'])
+          expect(config.array2.inner).to eq(['item4', 'item5', 'item6'])
+          expect(config.array3).to eq([])
+        end
+      end
+    end
   end
 end

--- a/spec/fixtures/overwrite_arrays/config1.yml
+++ b/spec/fixtures/overwrite_arrays/config1.yml
@@ -1,0 +1,17 @@
+array1:
+  - item1
+  - item2
+  - item3
+  - item4
+
+array2:
+  inner:
+    - item1
+    - item2
+    - item3
+    - item4
+
+array3:
+  - item1
+  - item2
+  - item3

--- a/spec/fixtures/overwrite_arrays/config2.yml
+++ b/spec/fixtures/overwrite_arrays/config2.yml
@@ -1,0 +1,12 @@
+array1:
+  - item2
+  - item4
+  - item5
+
+array2:
+  inner:
+    - item2
+    - item4
+    - item5
+
+array3: []

--- a/spec/fixtures/overwrite_arrays/config3.yml
+++ b/spec/fixtures/overwrite_arrays/config3.yml
@@ -1,0 +1,10 @@
+array1:
+  - item4
+  - item5
+  - item6
+
+array2:
+  inner:
+    - item4
+    - item5
+    - item6

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,9 +43,10 @@ RSpec.configure do |config|
 
       # Extend Config module with ability to reset configuration to the default values
       def self.reset
-        self.const_name      = 'Settings'
-        self.use_env         = false
-        self.knockout_prefix = nil
+        self.const_name       = 'Settings'
+        self.use_env          = false
+        self.knockout_prefix  = nil
+        self.overwrite_arrays = false
       end
     end
   end


### PR DESCRIPTION
I took Fryguy's commit to add the overwrite arrays option and pushed the gem myself to rubygems. It looks like the deep_merge gem latest release was in 2011.

https://github.com/railsconfig/config/pull/137
