### PR TITLE
Add Hash as a source.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## ...
+
+* Added support for passing a raw ruby hash into to both `Settings.add_source!` and `Settings.prepend_source!`.
+
 ## 1.3.0
 
 * **WARNING:** Overwrite arrays found in previously loaded settings file ([#137](https://github.com/railsconfig/config/pull/137) thanks to [@Fryguy](https://github.com/Fryguy) and [@dtaniwaki](https://github.com/dtaniwaki)) - this is a change breaking previous behaviour. If you want to keep Config to work as before, which is merging arrays found in following loaded settings file, please add `config.overwrite_arrays = false` to your Config initializer 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,15 @@ Settings.reload!
 > Note: this is an example usage, it is easier to just use the default local files `settings.local.yml,
 settings/#{Rails.env}.local.yml and environments/#{Rails.env}.local.yml` for your developer specific settings.
 
+You also have the option to add a raw hash as a source. One use case might be storing settings in the database or in environment variables that overwrite what is in the YML files.
+
+```ruby
+Settings.add_source!({some_secret: ENV['some_secret']})
+Settings.reload!
+```
+
+You may pass a hash to `prepend_source!` as well.
+
 ## Embedded Ruby (ERB)
 
 Embedded Ruby is allowed in the configuration files. Consider the two following config files.

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -5,6 +5,7 @@ require 'config/options'
 require 'config/version'
 require 'config/integrations/rails/engine' if defined?(::Rails)
 require 'config/sources/yaml_source'
+require 'config/sources/hash_source'
 require 'deep_merge'
 
 module Config

--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -15,6 +15,7 @@ module Config
     def add_source!(source)
       # handle yaml file paths
       source = (Sources::YAMLSource.new(source)) if source.is_a?(String)
+      source = (Sources::HashSource.new(source)) if source.is_a?(Hash)
 
       @config_sources ||= []
       @config_sources << source
@@ -22,6 +23,7 @@ module Config
 
     def prepend_source!(source)
       source = (Sources::YAMLSource.new(source)) if source.is_a?(String)
+      source = (Sources::HashSource.new(source)) if source.is_a?(Hash)
 
       @config_sources ||= []
       @config_sources.unshift(source)

--- a/lib/config/sources/hash_source.rb
+++ b/lib/config/sources/hash_source.rb
@@ -1,0 +1,16 @@
+module Config
+  module Sources
+    class HashSource
+      attr_accessor :hash
+
+      def initialize(hash)
+        @hash = hash
+      end
+
+      # returns hash that was passed in to initialize
+      def load
+        hash.is_a?(Hash) ? hash : {}
+      end
+    end
+  end
+end

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -39,7 +39,7 @@ describe Config::Options do
       expect(config['tvrage']['service_url']).to eq('http://services.tvrage.com')
     end
 
-    context 'overwrite' do
+    context 'overwrite with YAML file' do
       before do
         config.add_source!("#{fixture_path}/deep_merge2/config2.yml")
         config.reload!
@@ -47,6 +47,18 @@ describe Config::Options do
 
       it 'should overwrite the previous values' do
         expect(config['tvrage']['service_url']).to eq('http://url2')
+      end
+
+    end
+
+    context 'overwrite with Hash' do
+      before do
+        config.add_source!({tvrage: {service_url: 'http://url3'}})
+        config.reload!
+      end
+
+      it 'should overwrite the previous values' do
+        expect(config['tvrage']['service_url']).to eq('http://url3')
       end
     end
   end
@@ -77,6 +89,24 @@ describe Config::Options do
 
       it 'should overwrite the previous values' do
         expect(config['tvrage']['service_url']).to eq('http://services.tvrage.com')
+      end
+    end
+
+    context 'source is a hash' do
+      let(:hash_source) {
+        { tvrage: { service_url: 'http://url3' }, meaning_of_life: 42 }
+      }
+      before do
+        config.prepend_source!(hash_source)
+        config.reload!
+      end
+
+      it 'should be overwriten by the following values' do
+        expect(config['tvrage']['service_url']).to eq('http://services.tvrage.com')
+      end
+
+      it 'should set meaning of life' do
+        expect(config['meaning_of_life']).to eq(42)
       end
     end
   end

--- a/spec/sources/hash_source_spec.rb
+++ b/spec/sources/hash_source_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+module Config::Sources
+  describe HashSource do
+    it "should take a hash as initializer" do
+      source = HashSource.new(foo: 5)
+      expect(source.hash).to eq(foo: 5)
+    end
+
+    context "basic hash" do
+      let(:source) do
+        HashSource.new(
+          {
+            "size" => 2,
+            "section" => {
+              "size" => 3,
+              "servers" => [ {"name" => "yahoo.com"}, {"name" => "amazon.com"} ]
+            }
+          }
+        )
+      end
+
+      it "should properly read the settings" do
+        results = source.load
+        expect(results["size"]).to eq(2)
+      end
+
+      it "should properly read nested settings" do
+        results = source.load
+        expect(results["section"]["size"]).to eq(3)
+        expect(results["section"]["servers"]).to be_instance_of(Array)
+        expect(results["section"]["servers"].size).to eq(2)
+      end
+    end
+
+    context "parameter is not a hash" do
+      let(:source) do
+        HashSource.new "hello world"
+      end
+
+      it "should return an empty hash" do
+        results = source.load
+        expect(results).to eq({})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add the option to add raw ruby hash as a source.

```ruby
Settings.add_source!({some_secret: ENV['some_secret']})
Settings.prepend_source!({default_something: 'yes'})
Settings.reload!
```