### PR TITLE
#to_hash should not replace nested config objects with Hash

### DIFF
--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -148,15 +148,15 @@ module Config
     protected
 
     def descend_array(array)
-      array.length.times do |i|
-        value = array[i]
+      array.map do |value|
         if value.instance_of? Config::Options
-          array[i] = value.to_hash
+          value.to_hash
         elsif value.instance_of? Array
-          array[i] = descend_array(value)
+          descend_array(value)
+        else
+          value
         end
       end
-      array
     end
 
     # Recursively converts Hashes to Options (including Hashes inside Arrays)

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -60,6 +60,15 @@ describe Config do
     expect(servers).to eq([{ name: "yahoo.com" }, { name: "amazon.com" }])
   end
 
+  it "should convert to a hash without modifying nested settings" do
+    config = Config.load_files("#{fixture_path}/development.yml")
+    config.to_hash
+    expect(config).to be_kind_of(Config::Options)
+    expect(config[:section]).to be_kind_of(Config::Options)
+    expect(config[:section][:servers][0]).to be_kind_of(Config::Options)
+    expect(config[:section][:servers][1]).to be_kind_of(Config::Options)
+  end
+
   it "should convert to a json" do
     config = Config.load_files("#{fixture_path}/development.yml").to_json
     expect(JSON.parse(config)["section"]["servers"]).to be_kind_of(Array)


### PR DESCRIPTION
`Config::Options#to_hash` mistakenly replaces nested `Config::Options`
objects in arrays with `Hash` objects. Consider the following code:

```ruby
> config = Config.load_files("spec/fixtures/development.yml");
> config.section.servers[0].class
Config::Options
> config.to_hash
{:size=>2, :section=>{:size=>3, :servers=>[{:name=>"yahoo.com"}, {:name=>"amazon.com"}]}}
> config.section.servers[0].class
Hash
```

Therefore, after evaluating `config.to_hash`,
`config.sections.servers[0].name` raises an exception.
This is because `Config::Options#descend_array` overwrites array elements.

This commit fixes the above problem by modifying the
`Config::Options#descend_array`.