### PR TITLE
Add count to the reserved names list

### DIFF
--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -131,7 +131,7 @@ module Config
     end
 
     # Some keywords that don't play nicely with OpenStruct
-    SETTINGS_RESERVED_NAMES = %w{select collect test}
+    SETTINGS_RESERVED_NAMES = %w{select collect test count}
 
     # An alternative mechanism for property access.
     # This let's you do foo['bar'] along with foo.bar.

--- a/spec/fixtures/reserved_keywords.yml
+++ b/spec/fixtures/reserved_keywords.yml
@@ -1,2 +1,3 @@
 select: 123
 collect: 456
+count: 789

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -10,14 +10,17 @@ describe Config::Options do
     it 'should allow to access them via object member notation' do
       expect(config.select).to eq(123)
       expect(config.collect).to eq(456)
+      expect(config.count).to eq(789)
     end
 
     it 'should allow to access them using [] operator' do
       expect(config['select']).to eq(123)
       expect(config['collect']).to eq(456)
+      expect(config['count']).to eq(789)
 
       expect(config[:select]).to eq(123)
       expect(config[:collect]).to eq(456)
+      expect(config[:count]).to eq(789)
     end
   end
 


### PR DESCRIPTION
We ran into this issue by using `:count` as a key in our settings [here](https://github.com/ManageIQ/manageiq/blob/542ae37e1c4c0a1917c0d3bd9fcd4e5f4864d19d/config/settings.yml#L1182)

/cc @yrudman @Fryguy 