### PR TITLE
Allow a custom environment variable prefix to include the environment variable separator

### DIFF
--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -39,7 +39,9 @@ module Config
       ENV.each do |variable, value|
         keys = variable.to_s.split(Config.env_separator)
 
-        next if keys.shift != (Config.env_prefix || Config.const_name)
+        prefix = (Config.env_prefix || Config.const_name).to_s.split(Config.env_separator)
+
+        next if keys.shift(prefix.size) != prefix
 
         keys.map! { |key|
           case Config.env_converter

--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -37,9 +37,10 @@ module Config
       hash = Hash.new
 
       ENV.each do |variable, value|
-        keys = variable.to_s.split(Config.env_separator)
+        separator = Config.env_separator
+        prefix = (Config.env_prefix || Config.const_name).to_s.split(separator)
 
-        prefix = (Config.env_prefix || Config.const_name).split(Config.env_separator)
+        keys = variable.to_s.split(separator)
 
         next if keys.shift(prefix.size) != prefix
 

--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -37,9 +37,9 @@ module Config
       hash = Hash.new
 
       ENV.each do |variable, value|
-        keys = split(variable)
+        keys = variable.to_s.split(Config.env_separator)
 
-        prefix = split(Config.env_prefix || Config.const_name)
+        prefix = (Config.env_prefix || Config.const_name).split(Config.env_separator)
 
         next if keys.shift(prefix.size) != prefix
 
@@ -153,10 +153,6 @@ module Config
     end
 
     protected
-
-    def split(string)
-      string.to_s.split(Config.env_separator)
-    end
 
     def descend_array(array)
       array.map do |value|

--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -37,9 +37,9 @@ module Config
       hash = Hash.new
 
       ENV.each do |variable, value|
-        keys = variable.to_s.split(Config.env_separator)
+        keys = split(variable)
 
-        prefix = (Config.env_prefix || Config.const_name).to_s.split(Config.env_separator)
+        prefix = split(Config.env_prefix || Config.const_name)
 
         next if keys.shift(prefix.size) != prefix
 
@@ -153,6 +153,10 @@ module Config
     end
 
     protected
+
+    def split(string)
+      string.to_s.split(Config.env_separator)
+    end
 
     def descend_array(array)
       array.map do |value|

--- a/spec/config_env_spec.rb
+++ b/spec/config_env_spec.rb
@@ -126,6 +126,47 @@ describe Config do
       end
     end
 
+    context 'and custom ENV variables prefix includes custom ENV variables separator' do
+      before :each do
+        Config.env_prefix = 'MY_CONFIG'
+        Config.env_separator = '_'
+      end
+
+      it 'should load variables from the new prefix' do
+        ENV['MY_CONFIG_KEY'] = 'value'
+
+        expect(config.key).to eq('value')
+      end
+
+      it 'should not load variables from the default prefix' do
+        ENV['Settings_key'] = 'value'
+
+        expect(config.key).to eq(nil)
+      end
+
+      it 'should skip ENV variable when partial prefix match' do
+        ENV['MY_CONFIGS_KEY'] = 'value'
+
+        expect(config.key).to eq(nil)
+      end
+
+      it 'should load variables and correctly recognize the new separator' do
+        ENV['MY_CONFIG_KEY']                    = 'value'
+        ENV['MY_CONFIG_KEY.WITH.DOT']           = 'value'
+        ENV['MY_CONFIG_WORLD_COUNTRIES_EUROPE'] = '0'
+
+        expect(config.key).to eq('value')
+        expect(config['key.with.dot']).to eq('value')
+        expect(config.world.countries.europe).to eq(0)
+      end
+
+      it 'should ignore variables wit default separator' do
+        ENV['MY_CONFIG.KEY'] = 'value'
+
+        expect(config.key).to eq(nil)
+      end
+    end
+
     context 'and variable names conversion is enabled' do
       it 'should downcase variable names when :downcase conversion enabled' do
         ENV['Settings.NEW_VAR'] = 'value'

--- a/spec/config_env_spec.rb
+++ b/spec/config_env_spec.rb
@@ -132,35 +132,33 @@ describe Config do
         Config.env_separator = '_'
       end
 
-      it 'should load variables from the new prefix' do
+      it 'should load environment variables which begin with the custom prefix' do
         ENV['MY_CONFIG_KEY'] = 'value'
 
         expect(config.key).to eq('value')
       end
 
-      it 'should not load variables from the default prefix' do
+      it 'should not load environment variables which begin with the default prefix' do
         ENV['Settings_key'] = 'value'
 
         expect(config.key).to eq(nil)
       end
 
-      it 'should skip ENV variable when partial prefix match' do
+      it 'should not load environment variables which partially begin with the custom prefix' do
         ENV['MY_CONFIGS_KEY'] = 'value'
 
         expect(config.key).to eq(nil)
       end
 
-      it 'should load variables and correctly recognize the new separator' do
-        ENV['MY_CONFIG_KEY']                    = 'value'
+      it 'should recognize the custom separator' do
         ENV['MY_CONFIG_KEY.WITH.DOT']           = 'value'
         ENV['MY_CONFIG_WORLD_COUNTRIES_EUROPE'] = '0'
 
-        expect(config.key).to eq('value')
         expect(config['key.with.dot']).to eq('value')
         expect(config.world.countries.europe).to eq(0)
       end
 
-      it 'should ignore variables wit default separator' do
+      it 'should not recognize the default separator' do
         ENV['MY_CONFIG.KEY'] = 'value'
 
         expect(config.key).to eq(nil)


### PR DESCRIPTION
Currently, given the following configuration:
```
Config.setup do |config|
  config.use_env = true
  config.env_prefix = 'MY_CONFIG'
  config.env_separator = '_'
  config.env_converter = :downcase
  config.env_parse_values = true
end
```
an environment variable, such as `MY_CONFIG_USERNAME=rdodson41`, will be split into `['MY', 'CONFIG', 'USERNAME']`, and, therefore will fail to match against the prefix `MY_CONFIG`.

This pull request will allow a custom environment variable prefix to include the environment variable separator by splitting the prefix on the separator and, only then, comparing the beginning of the split variable name to the split prefix. As a result, `['MY', 'CONFIG', 'USERNAME']` will successfully match against the prefix `MY_CONFIG`, which would be split into `['MY', 'CONFIG']`.

I don't think that this is a breaking change, as currently, given such a configuration, no environment variables would be merged into the configuration, but I am not completely sure.