### PR TITLE
Change Default Constant from Settings to RailsConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Config helps you easily manage environment specific settings in an easy and usab
 * config files support ERB
 * config files support inheritance and multiple environments
 * access config information via convenient object member notation
-* support for multi-level settings (`Settings.group.subgroup.setting`)
+* support for multi-level settings (`RailsConfig.group.subgroup.setting`)
 * local developer settings ignored when committing the code
 
 ## Compatibility
@@ -80,10 +80,10 @@ paths to load from.
 Config.load_and_set_settings("/path/to/yaml1", "/path/to/yaml2", ...)
 ```
 
-## Accessing the Settings object
+## Accessing the RailsConfig object
 
-After installing the gem, `Settings` object will become available globally and by default will be compiled from the
-files listed below. Settings defined in files that are lower in the list override settings higher.
+After installing the gem, `RailsConfig` object will become available globally and by default will be compiled from the
+files listed below. RailsConfig defined in files that are lower in the list override settings higher.
 
     config/settings.yml
     config/settings/#{environment}.yml
@@ -96,37 +96,37 @@ files listed below. Settings defined in files that are lower in the list overrid
 Entries can be accessed via object member notation:
 
 ```ruby
-Settings.my_config_entry
+RailsConfig.my_config_entry
 ```
 
 Nested entries are supported:
 
 ```ruby
-Settings.my_section.some_entry
+RailsConfig.my_section.some_entry
 ```
 
 Alternatively, you can also use the `[]` operator if you don't know which exact setting you need to access ahead of time.
 
 ```ruby
-# All the following are equivalent to Settings.my_section.some_entry
-Settings.my_section[:some_entry]
-Settings.my_section['some_entry']
-Settings[:my_section][:some_entry]
+# All the following are equivalent to RailsConfig.my_section.some_entry
+RailsConfig.my_section[:some_entry]
+RailsConfig.my_section['some_entry']
+RailsConfig[:my_section][:some_entry]
 ```
 
 ### Reloading settings
 
-You can reload the Settings object at any time by running `Settings.reload!`.
+You can reload the RailsConfig object at any time by running `RailsConfig.reload!`.
 
 ### Reloading settings and config files
 
-You can also reload the `Settings` object from different config files at runtime.
+You can also reload the `RailsConfig` object from different config files at runtime.
 
 For example, in your tests if you want to test the production settings, you can:
 
 ```ruby
 Rails.env = "production"
-Settings.reload_from_files(
+RailsConfig.reload_from_files(
   Rails.root.join("config", "settings.yml").to_s,
   Rails.root.join("config", "settings", "#{Rails.env}.yml").to_s,
   Rails.root.join("config", "environments", "#{Rails.env}.yml").to_s
@@ -166,8 +166,8 @@ Rails.root.join("config", "environments", "#{Rails.env}.local.yml").to_s
 You can add new YAML config files at runtime. Just use:
 
 ```ruby
-Settings.add_source!("/path/to/source.yml")
-Settings.reload!
+RailsConfig.add_source!("/path/to/source.yml")
+RailsConfig.reload!
 ```
 
 This will use the given source.yml file and use its settings to overwrite any previous ones.
@@ -175,8 +175,8 @@ This will use the given source.yml file and use its settings to overwrite any pr
 On the other hand, you can prepend a YML file to the list of configuration files:
 
 ```ruby
-Settings.prepend_source!("/path/to/source.yml")
-Settings.reload!
+RailsConfig.prepend_source!("/path/to/source.yml")
+RailsConfig.reload!
 ```
 
 This will do the same as `add_source`, but the given YML file will be loaded first (instead of last) and its settings
@@ -186,8 +186,8 @@ One thing I like to do for my Rails projects is provide a local.yml config file 
 per developer). Then I create a new initializer in `config/initializers/add_local_config.rb` with the contents
 
 ```ruby
-Settings.add_source!("#{Rails.root}/config/settings/local.yml")
-Settings.reload!
+RailsConfig.add_source!("#{Rails.root}/config/settings/local.yml")
+RailsConfig.reload!
 ```
 
 > Note: this is an example usage, it is easier to just use the default local files `settings.local.yml,
@@ -196,8 +196,8 @@ settings/#{Rails.env}.local.yml and environments/#{Rails.env}.local.yml` for you
 You also have the option to add a raw hash as a source. One use case might be storing settings in the database or in environment variables that overwrite what is in the YML files.
 
 ```ruby
-Settings.add_source!({some_secret: ENV['some_secret']})
-Settings.reload!
+RailsConfig.add_source!({some_secret: ENV['some_secret']})
+RailsConfig.reload!
 ```
 
 You may pass a hash to `prepend_source!` as well.
@@ -226,27 +226,27 @@ section:
 Notice that the environment specific config entries overwrite the common entries.
 
 ```ruby
-Settings.size   # => 2
-Settings.server # => google.com
+RailsConfig.size   # => 2
+RailsConfig.server # => google.com
 ```
 
 Notice the embedded Ruby.
 
 ```ruby
-Settings.computed # => 6
+RailsConfig.computed # => 6
 ```
 
 Notice that object member notation is maintained even in nested entries.
 
 ```ruby
-Settings.section.size # => 3
+RailsConfig.section.size # => 3
 ```
 
 Notice array notation and object member notation is maintained.
 
 ```ruby
-Settings.section.servers[0].name # => yahoo.com
-Settings.section.servers[1].name # => amazon.com
+RailsConfig.section.servers[0].name # => yahoo.com
+RailsConfig.section.servers[1].name # => amazon.com
 ```
 
 ## Configuration
@@ -256,7 +256,7 @@ application initialization phase:
 
 ```ruby
 Config.setup do |config|
-  config.const_name = 'Settings'
+  config.const_name = 'RailsConfig'
   ...
 end
 ```
@@ -266,7 +266,7 @@ located at `config/initializers/config.rb`.
 
 ### General
 
-* `const_name` - name of the object holing you settings. Default: `'Settings'`
+* `const_name` - name of the object holing you settings. Default: `'RailsConfig'`
 
 ### Merge customization
 
@@ -310,17 +310,17 @@ to true in your `config/initializers/config.rb` file:
 
 ```ruby
 Config.setup do |config|
-  config.const_name = 'Settings'
+  config.const_name = 'RailsConfig'
   config.use_env = true
 end
 ```
 
 Now config would read values from the ENV object to the settings. For the example above it would look for keys starting
-with `Settings`:
+with `RailsConfig`:
 
 ```ruby
-ENV['Settings.section.size'] = 1
-ENV['Settings.section.server'] = 'google.com'
+ENV['RailsConfig.section.size'] = 1
+ENV['RailsConfig.section.server'] = 'google.com'
 ```
 
 It won't work with arrays, though.
@@ -368,8 +368,8 @@ end
 The following settings will be available:
 
 ```ruby
-Settings.section.server_size # => 1
-Settings.section.server # => 'google.com'
+RailsConfig.section.server_size # => 1
+RailsConfig.section.server # => 'google.com'
 ```
 
 ## Contributing

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -16,7 +16,7 @@ module Config
   @@_ran_once = false
 
   mattr_accessor :const_name, :use_env, :env_prefix, :env_separator, :env_converter, :env_parse_values
-  @@const_name = 'Settings'
+  @@const_name = 'RailsConfig'
   @@use_env    = false
   @@env_prefix = @@const_name
   @@env_separator = '.'

--- a/lib/generators/config/templates/config.rb
+++ b/lib/generators/config/templates/config.rb
@@ -1,6 +1,6 @@
 Config.setup do |config|
   # Name of the constant exposing loaded settings
-  config.const_name = 'Settings'
+  config.const_name = 'RailsConfig'
 
   # Ability to remove elements of the array set in earlier loaded settings file. For example value: '--'.
   #
@@ -16,7 +16,7 @@ Config.setup do |config|
 
   # Define ENV variable prefix deciding which variables to load into config.
   #
-  # config.env_prefix = 'Settings'
+  # config.env_prefix = 'RailsConfig'
 
   # What string to use as level separator for settings loaded from ENV variables. Default value of '.' works well
   # with Heroku, but you might want to change it for example for '__' to easy override settings from command line, where

--- a/spec/app/rails_3/config/database.yml
+++ b/spec/app/rails_3/config/database.yml
@@ -5,7 +5,7 @@
 #   gem 'sqlite3'
 development:
   adapter: sqlite3
-  database: <%= Settings.databases.development.database %>
+  database: <%= RailsConfig.databases.development.database %>
   pool: 5
   timeout: 5000
 
@@ -14,12 +14,12 @@ development:
 # Do not set this db to the same as development or production.
 test:
   adapter: sqlite3
-  database: <%= Settings.databases.test.database %>
+  database: <%= RailsConfig.databases.test.database %>
   pool: 5
   timeout: 5000
 
 production:
   adapter: sqlite3
-  database: <%= Settings.databases.production.database %>
+  database: <%= RailsConfig.databases.production.database %>
   pool: 5
   timeout: 5000

--- a/spec/app/rails_4.1/config/database.yml
+++ b/spec/app/rails_4.1/config/database.yml
@@ -5,7 +5,7 @@
 #   gem 'sqlite3'
 development:
   adapter: sqlite3
-  database: <%= Settings.databases.development.database %>
+  database: <%= RailsConfig.databases.development.database %>
   pool: 5
   timeout: 5000
 
@@ -14,12 +14,12 @@ development:
 # Do not set this db to the same as development or production.
 test:
   adapter: sqlite3
-  database: <%= Settings.databases.test.database %>
+  database: <%= RailsConfig.databases.test.database %>
   pool: 5
   timeout: 5000
 
 production:
   adapter: sqlite3
-  database: <%= Settings.databases.production.database %>
+  database: <%= RailsConfig.databases.production.database %>
   pool: 5
   timeout: 5000

--- a/spec/app/rails_4.2/config/database.yml
+++ b/spec/app/rails_4.2/config/database.yml
@@ -11,15 +11,15 @@ default: &default
 
 development:
   <<: *default
-  database: <%= Settings.databases.development.database %>
+  database: <%= RailsConfig.databases.development.database %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: <%= Settings.databases.test.database %>
+  database: <%= RailsConfig.databases.test.database %>
 
 production:
   <<: *default
-  database: <%= Settings.databases.production.database %>
+  database: <%= RailsConfig.databases.production.database %>

--- a/spec/app/rails_4/config/database.yml
+++ b/spec/app/rails_4/config/database.yml
@@ -5,7 +5,7 @@
 #   gem 'sqlite3'
 development:
   adapter: sqlite3
-  database: <%= Settings.databases.development.database %>
+  database: <%= RailsConfig.databases.development.database %>
   pool: 5
   timeout: 5000
 
@@ -14,12 +14,12 @@ development:
 # Do not set this db to the same as development or production.
 test:
   adapter: sqlite3
-  database: <%= Settings.databases.test.database %>
+  database: <%= RailsConfig.databases.test.database %>
   pool: 5
   timeout: 5000
 
 production:
   adapter: sqlite3
-  database: <%= Settings.databases.production.database %>
+  database: <%= RailsConfig.databases.production.database %>
   pool: 5
   timeout: 5000

--- a/spec/config_env_spec.rb
+++ b/spec/config_env_spec.rb
@@ -25,21 +25,21 @@ describe Config do
     end
 
     it 'should add new setting from ENV variable' do
-      ENV['Settings.new_var'] = 'value'
+      ENV['RailsConfig.new_var'] = 'value'
 
       expect(config.new_var).to eq('value')
     end
 
     context 'should override existing setting with a value from ENV variable' do
       it 'for a basic values' do
-        ENV['Settings.size'] = 'overwritten by env'
+        ENV['RailsConfig.size'] = 'overwritten by env'
 
         expect(config.size).to eq('overwritten by env')
       end
 
       it 'for multilevel sections' do
-        ENV['Settings.number_of_all_countries'] = '0'
-        ENV['Settings.world.countries.europe']  = '0'
+        ENV['RailsConfig.number_of_all_countries'] = '0'
+        ENV['RailsConfig.world.countries.europe']  = '0'
 
         expect(config.number_of_all_countries).to eq(0)
         expect(config.world.countries.europe).to eq(0)
@@ -49,21 +49,21 @@ describe Config do
 
     context 'and parsing ENV variable names is enabled' do
       it 'should recognize numbers and expose them as integers' do
-        ENV['Settings.new_var'] = '123'
+        ENV['RailsConfig.new_var'] = '123'
 
         expect(config.new_var).to eq(123)
         expect(config.new_var.is_a? Integer).to eq(true)
       end
 
       it 'should recognize fixed point numbers and expose them as float' do
-        ENV['Settings.new_var'] = '1.9'
+        ENV['RailsConfig.new_var'] = '1.9'
 
         expect(config.new_var).to eq(1.9)
         expect(config.new_var.is_a? Float).to eq(true)
       end
 
       it 'should leave strings intact' do
-        ENV['Settings.new_var'] = 'foobar'
+        ENV['RailsConfig.new_var'] = 'foobar'
 
         expect(config.new_var).to eq('foobar')
         expect(config.new_var.is_a? String).to eq(true)
@@ -72,7 +72,7 @@ describe Config do
 
     context 'and parsing ENV variable names is disabled' do
       it 'should not convert numbers to integers' do
-        ENV['Settings.new_var'] = '123'
+        ENV['RailsConfig.new_var'] = '123'
 
         Config.env_parse_values = false
 
@@ -92,7 +92,7 @@ describe Config do
       end
 
       it 'should not load variables from the default prefix' do
-        ENV['Settings.new_var'] = 'value'
+        ENV['RailsConfig.new_var'] = 'value'
 
         expect(config.new_var).to eq(nil)
       end
@@ -110,9 +110,9 @@ describe Config do
       end
 
       it 'should load variables and correctly recognize the new separator' do
-        ENV['Settings__new_var']                  = 'value'
-        ENV['Settings__var.with.dot']             = 'value'
-        ENV['Settings__world__countries__europe'] = '0'
+        ENV['RailsConfig__new_var']                  = 'value'
+        ENV['RailsConfig__var.with.dot']             = 'value'
+        ENV['RailsConfig__world__countries__europe'] = '0'
 
         expect(config.new_var).to eq('value')
         expect(config['var.with.dot']).to eq('value')
@@ -120,7 +120,7 @@ describe Config do
       end
 
       it 'should ignore variables wit default separator' do
-        ENV['Settings.new_var'] = 'value'
+        ENV['RailsConfig.new_var'] = 'value'
 
         expect(config.new_var).to eq(nil)
       end
@@ -167,7 +167,7 @@ describe Config do
 
     context 'and variable names conversion is enabled' do
       it 'should downcase variable names when :downcase conversion enabled' do
-        ENV['Settings.NEW_VAR'] = 'value'
+        ENV['RailsConfig.NEW_VAR'] = 'value'
 
         expect(config.new_var).to eq('value')
       end
@@ -175,7 +175,7 @@ describe Config do
 
     context 'and variable names conversion is disabled' do
       it 'should not change variable names by default' do
-        ENV['Settings.NEW_VAR'] = 'value'
+        ENV['RailsConfig.NEW_VAR'] = 'value'
 
         Config.env_converter = nil
 
@@ -185,7 +185,7 @@ describe Config do
     end
 
     it 'should always load ENV variables when reloading settings from files' do
-      ENV['Settings.new_var'] = 'value'
+      ENV['RailsConfig.new_var'] = 'value'
 
       expect(config.new_var).to eq('value')
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -90,13 +90,13 @@ describe Config do
   it "should allow full reload of the settings files" do
     files = ["#{fixture_path}/settings.yml"]
     Config.load_and_set_settings(files)
-    expect(Settings.server).to eq("google.com")
-    expect(Settings.size).to eq(1)
+    expect(RailsConfig.server).to eq("google.com")
+    expect(RailsConfig.size).to eq(1)
 
     files = ["#{fixture_path}/settings.yml", "#{fixture_path}/development.yml"]
-    Settings.reload_from_files(files)
-    expect(Settings.server).to eq("google.com")
-    expect(Settings.size).to eq(2)
+    RailsConfig.reload_from_files(files)
+    expect(RailsConfig.server).to eq("google.com")
+    expect(RailsConfig.size).to eq(2)
   end
 
 
@@ -146,7 +146,7 @@ describe Config do
 
   context "Custom Configuration" do
     it "should have the default settings constant as 'Settings'" do
-      expect(Config.const_name).to eq("Settings")
+      expect(Config.const_name).to eq("RailsConfig")
     end
 
     it "should be able to assign a different settings constant" do

--- a/spec/support/rails_helper.rb
+++ b/spec/support/rails_helper.rb
@@ -14,7 +14,7 @@ end
 def config_available?
   where = caller[0].split(':')[0].gsub(File.expand_path(File.dirname(__FILE__)), '')
 
-  if defined?(::Settings)
+  if defined?(::RailsConfig)
     puts "Config available in #{where}"
   else
     raise "Config not available in #{where}"


### PR DESCRIPTION
Yesterday I encountered an issue when using Settings as constant name, I have a code where I required to include SendGrid module, that module also has class Settings. Then I tried to call a config somewhere:

```
include SendGrid
Settings.my_api_key
```

Raise:

```
NoMethodError: undefined method `my_api_key' for SendGrid::Settings:Class
```

So I changed my constant to RailsConfig and it's working fine. I don't know if this issue more related to the Ruby itself or not, but as for why made this PR because the name "Settings" is too general and might conflict with other modules/gems. The name represent gem name as well. Since this huge changes, I don't really mind if rejected, I just want to share my thought.  :v: 

Also it's might related to this issue: https://github.com/railsconfig/config/issues/126
