### PR TITLE
Adds the option `raise_on_access_to_missing` (default `false`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### New features
 
-...
+* `Config#fail_on_missing` option (default `false`) to raise a `KeyError` exception when accessing a non-existing key
+* Add ability to test if a value was set for a given key with `key?` and `has_key?`
 
 ## 1.5.1
 

--- a/README.md
+++ b/README.md
@@ -299,6 +299,42 @@ between the schema and your config.
 
 Check [dry-validation](https://github.com/dry-rb/dry-validation) for more details.
 
+### Missing keys
+
+You can test if a value was set for a given key using `key?` and its alias `has_key?`:
+
+```ruby
+Settings.key?(:not_existing_key)
+# => false
+Settings.key?(:existing_key)
+# => true
+```
+
+By default, accessing to a missing key returns `nil`:
+
+```ruby
+Settings.key?(:not_existing_key)
+# => false
+Settings.not_existing_key
+# => nil
+```
+
+This is not "typos-safe". To solve this problem, you can configure the `fail_on_missing` option:
+
+```ruby
+Config.setup do |config|
+  config.fail_on_missing = true
+  # ...
+end
+```
+
+So it will raise a `KeyError` when accessing a non-existing key (similar to `Hash#fetch` behaviour):
+
+```ruby
+Settings.not_existing_key
+# => raises KeyError: key not found: :not_existing_key
+```
+
 ### Environment variables
 
 See section below for more details.

--- a/README.md
+++ b/README.md
@@ -301,25 +301,32 @@ Check [dry-validation](https://github.com/dry-rb/dry-validation) for more detail
 
 ### Missing keys
 
+For an example settings file:
+
+```yaml
+size: 1
+server: google.com
+```
+
 You can test if a value was set for a given key using `key?` and its alias `has_key?`:
 
 ```ruby
-Settings.key?(:not_existing_key)
+Settings.key?(:path)
 # => false
-Settings.key?(:existing_key)
+Settings.key?(:server)
 # => true
 ```
 
 By default, accessing to a missing key returns `nil`:
 
 ```ruby
-Settings.key?(:not_existing_key)
+Settings.key?(:path)
 # => false
-Settings.not_existing_key
+Settings.path
 # => nil
 ```
 
-This is not "typos-safe". To solve this problem, you can configure the `fail_on_missing` option:
+This is not "typo-safe". To solve this problem, you can configure the `fail_on_missing` option:
 
 ```ruby
 Config.setup do |config|
@@ -331,8 +338,8 @@ end
 So it will raise a `KeyError` when accessing a non-existing key (similar to `Hash#fetch` behaviour):
 
 ```ruby
-Settings.not_existing_key
-# => raises KeyError: key not found: :not_existing_key
+Settings.path
+# => raises KeyError: key not found: :path
 ```
 
 ### Environment variables

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -15,13 +15,15 @@ module Config
   # Ensures the setup only gets run once
   @@_ran_once = false
 
-  mattr_accessor :const_name, :use_env, :env_prefix, :env_separator, :env_converter, :env_parse_values
+  mattr_accessor :const_name, :use_env, :env_prefix, :env_separator,
+                 :env_converter, :env_parse_values, :fail_on_missing
   @@const_name = 'Settings'
   @@use_env    = false
   @@env_prefix = @@const_name
   @@env_separator = '.'
   @@env_converter = :downcase
   @@env_parse_values = true
+  @@fail_on_missing = false
 
   # deep_merge options
   mattr_accessor :knockout_prefix, :overwrite_arrays

--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -153,6 +153,19 @@ module Config
       end
     end
 
+    delegate :key?, :has_key?, to: :table
+
+    def method_missing(method_name, *args)
+      if Config.fail_on_missing && method_name !~ /.*(?==\z)/m
+        raise KeyError, "key not found: #{method_name.inspect}" unless key?(method_name)
+      end
+      super
+    end
+
+    def respond_to_missing?(*args)
+      super
+    end
+
     protected
 
     def descend_array(array)


### PR DESCRIPTION
This option will raise a `KeyError: "key not found: #{key.inspect}"` when trying to access non-existing keys.
It also includes the `key?(name)` (and its alias`has_key?(name)` too) to test if a value was set for a given key.

```ruby
Config.setup { |cfg| cfg.fail_on_missing = true }
config = Config.load_files("empty.yml")
config.key?(:not_existing)
# => false
config.not_existing
# KeyError: key not found: :not_existing
```
Fixes #171, Fixes #77, Fixes #43 