### PR TITLE
Allow newer dry validation dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-...
+## 1.6.1
+
+* Allow newer dry-validation dependency
 
 ## 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.6.1
 
-* Makje dry-validation dependency less strict allowing to use newer versions
+* Makje dry-validation dependency less strict allowing to use newer versions ([#183](https://github.com/railsconfig/config/pull/183))
 
 ## 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.6.1
 
-* Allow newer dry-validation dependency
+* Makje dry-validation dependency less strict allowing to use newer versions
 
 ## 1.6.0
 

--- a/config.gemspec
+++ b/config.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activesupport',           '>= 3.0'
   s.add_dependency 'deep_merge',              '~> 1.1.1'
-  s.add_dependency 'dry-validation',          '~> 0.10.4' if RUBY_VERSION >= '2.1'
+  s.add_dependency 'dry-validation',          '>= 0.10.4' if RUBY_VERSION >= '2.1'
 
   s.add_development_dependency 'bundler',     '~> 1.13',  '>= 1.13.6'
   s.add_development_dependency 'rake',        '~> 12.0',  '>= 12.0.0'


### PR DESCRIPTION
Hey,

We are using dry-validation 0.11.1 on our project and we would like to add config gem into it, I've updated the dependency version.

Specs are green 👌 