### PR TITLE
Replace Config::Options#delegate to simple method definitions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,17 @@ gemfile:
   - gemfiles/rails_4.1.gemfile
   - gemfiles/rails_4.2.gemfile
   - gemfiles/rails_5.gemfile
+  - gemfiles/sinatra.gemfile
 matrix:
   exclude:
     - rvm: 2.0.0
       gemfile: gemfiles/rails_5.gemfile
+    - rvm: 2.0.0
+      gemfile: gemfiles/sinatra.gemfile
     - rvm: 2.1.10
       gemfile: gemfiles/rails_5.gemfile
+    - rvm: 2.1.10
+      gemfile: gemfiles/sinatra.gemfile
     - rvm: 2.2.6
       gemfile: gemfiles/rails_3.gemfile
     - rvm: 2.3.3

--- a/Appraisals
+++ b/Appraisals
@@ -19,3 +19,7 @@ end
 appraise 'rails-5' do
   gem 'rails', '5.0.1'
 end
+
+appraise 'sinatra' do
+  gem 'sinatra', '2.0.0'
+end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-...
+### Bug fixes
+* Fix `key?` and `has_key?` which have raised NoMethodError in not rails environment by using ActiveSupport `#delegate` implicitly
 
 ## 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Bug fixes
-* Fix `key?` and `has_key?` which have raised NoMethodError in not rails environment by using ActiveSupport `#delegate` implicitly
+* Fix `key?` and `has_key?`, which raise NoMethodError in non Rails environment, by using ActiveSupport `#delegate` implicitly
 
 ## 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Makje dry-validation dependency less strict allowing to use newer versions ([#183](https://github.com/railsconfig/config/pull/183))
+* Make dry-validation dependency less strict allowing to use newer versions ([#183](https://github.com/railsconfig/config/pull/183))
 * Fix `key?` and `has_key?`, which raise NoMethodError in non Rails environment, by using ActiveSupport `#delegate` implicitly ([#185](https://github.com/railsconfig/config/pull/185))
 
 ## 1.6.0

--- a/gemfiles/rails_3.gemfile
+++ b/gemfiles/rails_3.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "rails", "3.2.22.4"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "4.2.7.1"
-gem "tzinfo-data", :platforms => [:mingw, :mswin, :x64_mingw]
+gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_4.gemfile
+++ b/gemfiles/rails_4.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "rails", "4.0.13"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "rails", "5.0.1"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/sinatra.gemfile
+++ b/gemfiles/sinatra.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "4.1.16"
-gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw]
+gem "sinatra", "2.0.0"
 
 gemspec path: "../"

--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -153,7 +153,13 @@ module Config
       end
     end
 
-    delegate :key?, :has_key?, to: :table
+    def key?
+      table.key?
+    end
+
+    def has_key?
+      table.has_key?
+    end
 
     def method_missing(method_name, *args)
       if Config.fail_on_missing && method_name !~ /.*(?==\z)/m

--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -153,12 +153,12 @@ module Config
       end
     end
 
-    def key?
-      table.key?
+    def key?(key)
+      table.key?(key)
     end
 
-    def has_key?
-      table.has_key?
+    def has_key?(key)
+      table.has_key?(key)
     end
 
     def method_missing(method_name, *args)

--- a/spec/app/sinatra/app.rb
+++ b/spec/app/sinatra/app.rb
@@ -1,0 +1,9 @@
+require 'sinatra'
+require File.expand_path('../../../../lib/config', __FILE__)
+
+set :root, File.dirname(__FILE__)
+register Config
+
+get '/' do
+  'Hello world!'
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ end
 Dir['./spec/support/**/*.rb'].each { |f| require f }
 
 ##
-# Load Rails dummy application based on gemfile name substituted by Appraisal
+# Detect Rails/Sinatra dummy application based on gemfile name substituted by Appraisal
 #
 if ENV['APPRAISAL_INITIALIZED'] || ENV['TRAVIS']
   app_name = Pathname.new(ENV['BUNDLE_GEMFILE']).basename.sub('.gemfile', '')
@@ -22,19 +22,47 @@ else
   app_name = 'rails_5'
 end
 
-require File.expand_path("../../spec/app/#{app_name}/config/environment", __FILE__)
-
-APP_RAKEFILE = File.expand_path("../../spec/app/#{app_name}/Rakefile", __FILE__)
+app_framework = %w{rails sinatra}.find { |f| app_name.to_s.include?(f) }
 
 ##
-# Load Rspec
+# Load dummy application and Rspec
 #
-require 'rspec/rails'
+case app_framework
+when 'rails'
+  # Load Rails
+  require File.expand_path("../app/#{app_name}/config/environment", __FILE__)
 
-# Configure
+  APP_RAKEFILE = File.expand_path("../app/#{app_name}/Rakefile", __FILE__)
+
+  # Load Rspec
+  require 'rspec/rails'
+
+  # Configure
+  RSpec.configure do |config|
+    config.fixture_path = File.join(File.dirname(__FILE__), '/fixtures')
+  end
+
+when 'sinatra'
+  # Load Sinatra
+  require File.expand_path("../app/#{app_name}/app", __FILE__)
+
+  # Load Rspec
+  require 'rspec'
+
+  # Configure
+  RSpec.configure do |config|
+    config.filter_run_excluding :rails
+
+    def fixture_path
+      File.join(File.dirname(__FILE__), '/fixtures')
+    end
+  end
+end
+
+##
+# Common Rspec configure
+#
 RSpec.configure do |config|
-  config.fixture_path = File.join(File.dirname(__FILE__), '/fixtures')
-
   # Turn the deprecation warnings into errors, giving you the full backtrace
   config.raise_errors_for_deprecations!
 
@@ -54,16 +82,15 @@ RSpec.configure do |config|
   end
 end
 
-
 ##
 # Print some debug info
 #
 puts
 puts "Gemfile: #{ENV['BUNDLE_GEMFILE']}"
-puts 'Rails version:'
+puts 'Version:'
 
 Gem.loaded_specs.each { |name, spec|
-  puts "\t#{name}-#{spec.version}" if %w{rails activesupport sqlite3 rspec-rails}.include?(name)
+  puts "\t#{name}-#{spec.version}" if %w{rails activesupport sqlite3 rspec-rails sinatra}.include?(name)
 }
 
 puts

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,7 +39,7 @@ when 'rails'
 
   # Configure
   RSpec.configure do |config|
-    config.fixture_path = File.join(File.dirname(__FILE__), '/fixtures')
+    config.fixture_path = FixtureHelper::FIXTURE_PATH
   end
 
 when 'sinatra'
@@ -52,10 +52,7 @@ when 'sinatra'
   # Configure
   RSpec.configure do |config|
     config.filter_run_excluding :rails
-
-    def fixture_path
-      File.join(File.dirname(__FILE__), '/fixtures')
-    end
+    config.include FixtureHelper
   end
 end
 

--- a/spec/support/fixture_helper.rb
+++ b/spec/support/fixture_helper.rb
@@ -1,0 +1,12 @@
+##
+# Config Fixture Helpers
+#
+
+module FixtureHelper
+  FIXTURE_PATH = File.expand_path('../../fixtures', __FILE__)
+
+  # Provide fixture path as same way as rspec-rails
+  def fixture_path
+    FIXTURE_PATH
+  end
+end

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -1,8 +1,0 @@
-require 'rake'
-
-shared_context 'rake' do
-
-  # include rails rake tasks
-  load 'rails/tasks/engine.rake'
-
-end

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -1,0 +1,9 @@
+shared_context 'rake' do
+
+  # include rails rake tasks
+  before do
+    require 'rake'
+    load 'rails/tasks/engine.rake'
+  end
+
+end

--- a/spec/tasks/db_spec.rb
+++ b/spec/tasks/db_spec.rb
@@ -1,7 +1,10 @@
 require 'spec_helper'
 
-describe 'db:create' do
-  include_context 'rake'
+describe 'db:create', :rails do
+  before do
+    require 'rake'
+    load 'rails/tasks/engine.rake'
+  end
 
   it 'has access to Settings object and can read databases from settings.yml file' do
     Rake::Task['db:create'].invoke

--- a/spec/tasks/db_spec.rb
+++ b/spec/tasks/db_spec.rb
@@ -1,10 +1,7 @@
 require 'spec_helper'
 
 describe 'db:create', :rails do
-  before do
-    require 'rake'
-    load 'rails/tasks/engine.rake'
-  end
+  include_context 'rake'
 
   it 'has access to Settings object and can read databases from settings.yml file' do
     Rake::Task['db:create'].invoke


### PR DESCRIPTION
Fix #184.

`Config::Options#delegate` is using ActiveSupport's `#delegate` implicitly. So it would raise
`NoMethodError` with running in not rails environment. e.g. Padrino, Sinatra and pure Ruby.

It could fix it by replacing to simple method definitions.