### PR TITLE
Padrino should respond to env and root

### DIFF
--- a/lib/config/integrations/sinatra.rb
+++ b/lib/config/integrations/sinatra.rb
@@ -14,8 +14,8 @@ module Config
 
       # use Padrino settings if applicable
       if defined?(Padrino)
-        env = Padrino.env
-        root = Padrino.root
+        env = Padrino.env if Padrino.respond_to?(:env)
+        root = Padrino.root if Padrino.respond_to?(:root)
       end
 
       Config.load_and_set_settings(Config.setting_files(File.join(root, 'config'), env))


### PR DESCRIPTION
## Summary

* In `lib/config/integrations/sinatra.rb`, `Padrino.env` and `Padrino.root` is called without `respond_to?` check
* But there are cases where only `padrino-helpers` is depended on, and `Padrino.env` and `Padrino.root` are not available, like `kaminari-sinatra`
    * See https://github.com/kaminari/kaminari-sinatra/blob/master/kaminari-sinatra.gemspec#L34