### PR TITLE
Restrict constant search to Kernel only (#189)

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -52,7 +52,7 @@ module Config
 
   # Loads and sets the settings constant!
   def self.load_and_set_settings(*files)
-    Kernel.send(:remove_const, Config.const_name) if Kernel.const_defined?(Config.const_name)
+    Kernel.send(:remove_const, Config.const_name) if Kernel.const_defined?(Config.const_name, false)
     Kernel.const_set(Config.const_name, Config.load_files(files))
   end
 

--- a/spec/const_loading_spec.rb
+++ b/spec/const_loading_spec.rb
@@ -1,0 +1,13 @@
+require "config"
+
+RSpec.describe Config do
+  let(:fixture_path) { File.expand_path('../fixtures', __FILE__) }
+  context "Object::Settings defined" do
+    it "should set Settings without throwing an error" do
+      Object.const_set(:Settings, "foo")
+      expect {
+        Config.load_and_set_settings("#{fixture_path}/settings.yml")
+      }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
This fixes #189 while retaining the warning suppression behavior.