### PR TITLE
Update deep_merge dependency to latest version (v1.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Make dry-validation dependency less strict allowing to use newer versions ([#183](https://github.com/railsconfig/config/pull/183))
 * Fix `key?` and `has_key?`, which raise NoMethodError in non Rails environment, by using ActiveSupport `#delegate` implicitly ([#185](https://github.com/railsconfig/config/pull/185))
+* Update `deep_merge` dependency to latest version (v1.2.1) ([#191](https://github.com/railsconfig/config/pull/191))
 
 ## 1.6.0
 

--- a/config.gemspec
+++ b/config.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0.0'
 
   s.add_dependency 'activesupport',           '>= 3.0'
-  s.add_dependency 'deep_merge',              '~> 1.1.1'
+  s.add_dependency 'deep_merge',              '~> 1.2.1'
   s.add_dependency 'dry-validation',          '>= 0.10.4' if RUBY_VERSION >= '2.1'
 
   s.add_development_dependency 'bundler',     '~> 1.13',  '>= 1.13.6'


### PR DESCRIPTION
Minor version bump from 1.1.1->1.2.1. Removes `deep_merge` from
showing up as an outdated gem in `bundle outdated` output (of Rails 5 application).

All specs pass after the update on my system.