### PR TITLE
Add `zip` to the list of reserved keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix `key?` and `has_key?`, which raise NoMethodError in non Rails environment, by using ActiveSupport `#delegate` implicitly ([#185](https://github.com/railsconfig/config/pull/185))
 * Update `deep_merge` dependency to latest version (v1.2.1) ([#191](https://github.com/railsconfig/config/pull/191))
 * Upgrade `rubocop` to version 0.52.1 ([#193](https://github.com/railsconfig/config/pull/193))
+* Add `zip` to the list of reserved keywords ([#197](https://github.com/railsconfig/config/pull/197))
 
 ## 1.6.0
 

--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -134,7 +134,7 @@ module Config
     end
 
     # Some keywords that don't play nicely with OpenStruct
-    SETTINGS_RESERVED_NAMES = %w{select collect test count zip}
+    SETTINGS_RESERVED_NAMES = %w[select collect test count zip].freeze
 
     # An alternative mechanism for property access.
     # This let's you do foo['bar'] along with foo.bar.

--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -134,7 +134,7 @@ module Config
     end
 
     # Some keywords that don't play nicely with OpenStruct
-    SETTINGS_RESERVED_NAMES = %w{select collect test count}
+    SETTINGS_RESERVED_NAMES = %w{select collect test count zip}
 
     # An alternative mechanism for property access.
     # This let's you do foo['bar'] along with foo.bar.

--- a/spec/fixtures/reserved_keywords.yml
+++ b/spec/fixtures/reserved_keywords.yml
@@ -1,3 +1,4 @@
-select: 123
-collect: 456
-count: 789
+select: apple
+collect: banana
+count: lemon
+zip: cherry

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -8,19 +8,22 @@ describe Config::Options do
     end
 
     it 'should allow to access them via object member notation' do
-      expect(config.select).to eq(123)
-      expect(config.collect).to eq(456)
-      expect(config.count).to eq(789)
+      expect(config.select).to eq('apple')
+      expect(config.collect).to eq('banana')
+      expect(config.count).to eq('lemon')
+      expect(config.zip).to eq('cherry')
     end
 
     it 'should allow to access them using [] operator' do
-      expect(config['select']).to eq(123)
-      expect(config['collect']).to eq(456)
-      expect(config['count']).to eq(789)
+      expect(config['select']).to eq('apple')
+      expect(config['collect']).to eq('banana')
+      expect(config['count']).to eq('lemon')
+      expect(config['zip']).to eq('cherry')
 
-      expect(config[:select]).to eq(123)
-      expect(config[:collect]).to eq(456)
-      expect(config[:count]).to eq(789)
+      expect(config[:select]).to eq('apple')
+      expect(config[:collect]).to eq('banana')
+      expect(config[:count]).to eq('lemon')
+      expect(config[:zip]).to eq('cherry')
     end
   end
 


### PR DESCRIPTION
When I call `Settings.some_setting.["zip"]` there always return Array
