### PR TITLE
⚠ loading in progress, circular require considered harmful

### DIFF
--- a/lib/config/validation/schema.rb
+++ b/lib/config/validation/schema.rb
@@ -1,5 +1,4 @@
 require 'dry-validation'
-require 'config/validation/schema'
 
 module Config
   module Validation


### PR DESCRIPTION
This `require` requires itself, then causes a ruby interpreter warning.
This can be reproduced by
```
% ruby -rconfig -wep
```
with current 1.7.1 gem.