### PR TITLE
Use bundler 1 on Travis CI for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
     - rvm: 2.6.0
       gemfile: gemfiles/rails_4.1.gemfile
 before_install:
-  - gem install bundler
+  - gem install bundler -v '<2'
 script:
   - bundle exec rspec
 addons:


### PR DESCRIPTION
Because we're still testing against ruby <2.3.0 that  is not supported by bundler 2 and rails 4.x that doesn't support bundler 2.x.