### PR TITLE
Fix env_prefix default in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ To upload your local values to Heroku you could ran `bundle exec rake config:her
 
 You can customize how environment variables are processed:
 
-* `env_prefix` (default: `SETTINGS`) - which ENV variables to load into config
+* `env_prefix` (default: `Settings`) - which ENV variables to load into config
 * `env_separator` (default: `.`)  - what string to use as level separator - default value of `.` works well with
   Heroku, but you might want to change it for example for `__` to easy override settings from command line, where using
   dots in variable names might not be allowed (eg. Bash)


### PR DESCRIPTION
I think env_prefix default in README is wrong.
https://github.com/railsconfig/config/blob/2439d5a41061cf303aa912ce7f03b8b7e69ada4d/lib/config.rb#L22