### PR TITLE
README.md: Update contributing instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,12 @@ Settings.section.ssl_enabled # => false
 
 ## Contributing
 
+Install appraisal
+```bash
+gem install bundler -v 1.17.3
+gem install appraisal
+```
+
 Bootstrap
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ Settings.section.ssl_enabled # => false
 ## Contributing
 
 Install appraisal
+
 ```bash
 gem install bundler -v 1.17.3
 gem install appraisal


### PR DESCRIPTION
The latest version of bundler doesn't support ruby 2.2.2, this gem is still supporting it.
This changes add instruction to install bundler that supports ruby 2.2.2.