### PR TITLE
[WIP] Switch to dry-schema

### DIFF
--- a/config.gemspec
+++ b/config.gemspec
@@ -26,8 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport',           '>= 3.0'
   s.add_dependency 'deep_merge',              '~> 1.2',   '>= 1.2.1'
 
-  s.add_dependency 'dry-validation',          '~> 0.10',  '>= 0.10.7' if RUBY_VERSION >= '2.1' && RUBY_VERSION < '2.2'
-  s.add_dependency 'dry-validation',          '~> 0.12',  '>= 0.12.2' if RUBY_VERSION >= '2.2'
+  s.add_dependency 'dry-schema',              '~> 0.6'
 
   s.add_development_dependency 'bundler',     '~> 1.13',  '>= 1.13.6'
   s.add_development_dependency 'rake',        '~> 12.0',  '>= 12.0.0'

--- a/config.gemspec
+++ b/config.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport',           '>= 3.0'
   s.add_dependency 'deep_merge',              '~> 1.2',   '>= 1.2.1'
 
-  s.add_dependency 'dry-schema',              '~> 0.6'
+  s.add_dependency 'dry-schema',              '~> 1.0'
 
   s.add_development_dependency 'bundler',     '~> 1.13',  '>= 1.13.6'
   s.add_development_dependency 'rake',        '~> 12.0',  '>= 12.0.0'

--- a/lib/config/validation/error.rb
+++ b/lib/config/validation/error.rb
@@ -3,7 +3,7 @@ module Config
     class Error < StandardError
 
       def self.format(v_res)
-        flatten_hash(v_res.messages).map do |field, msgs|
+        flatten_hash(v_res.errors.to_h).map do |field, msgs|
           "#{' ' * 2}#{field}: #{msgs.join('; ')}"
         end.join("\n")
       end

--- a/lib/config/validation/schema.rb
+++ b/lib/config/validation/schema.rb
@@ -1,4 +1,4 @@
-require 'dry-validation'
+require 'dry/schema'
 require 'config/validation/schema'
 
 module Config
@@ -10,7 +10,7 @@ module Config
 
       def schema(&block)
         if block_given?
-          @@schema = Dry::Validation.Schema(&block)
+          @@schema = Dry::Schema.define(&block)
         else
           @@schema
         end


### PR DESCRIPTION
This makes `config` work with `dry-schema` which replaced `dry-validation`'s schema DSL. The only caveat is that it works with `ruby >= 2.4`. Oh and of course CI is completely broken but I think there's something with your spec suite because I didn't manage to run specs locally either.

Let me know if this is something you'd like to merge eventually. I'm happy to help.

Fixes #222