### PR TITLE
Add `min` and `max` to reserved words list

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,12 @@ gem install bundler -v 1.17.3
 gem install appraisal
 ```
 
+Bundle
+
+```bash
+bundle install
+```
+
 Bootstrap
 
 ```bash

--- a/lib/config/options.rb
+++ b/lib/config/options.rb
@@ -143,7 +143,7 @@ module Config
     end
 
     # Some keywords that don't play nicely with OpenStruct
-    SETTINGS_RESERVED_NAMES = %w[select collect test count zip].freeze
+    SETTINGS_RESERVED_NAMES = %w[select collect test count zip min max].freeze
 
     # An alternative mechanism for property access.
     # This let's you do foo['bar'] along with foo.bar.

--- a/spec/fixtures/reserved_keywords.yml
+++ b/spec/fixtures/reserved_keywords.yml
@@ -2,3 +2,5 @@ select: apple
 collect: banana
 count: lemon
 zip: cherry
+max: kumquat
+min: fig

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -12,6 +12,8 @@ describe Config::Options do
       expect(config.collect).to eq('banana')
       expect(config.count).to eq('lemon')
       expect(config.zip).to eq('cherry')
+      expect(config.max).to eq('kumquat')
+      expect(config.min).to eq('fig')
     end
 
     it 'should allow to access them using [] operator' do
@@ -19,11 +21,15 @@ describe Config::Options do
       expect(config['collect']).to eq('banana')
       expect(config['count']).to eq('lemon')
       expect(config['zip']).to eq('cherry')
+      expect(config['max']).to eq('kumquat')
+      expect(config['min']).to eq('fig')
 
       expect(config[:select]).to eq('apple')
       expect(config[:collect]).to eq('banana')
       expect(config[:count]).to eq('lemon')
       expect(config[:zip]).to eq('cherry')
+      expect(config[:max]).to eq('kumquat')
+      expect(config[:min]).to eq('fig')
     end
   end
 


### PR DESCRIPTION
Fixes #234