### PR TITLE
Config doesn't have to be a Rails Engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Ignore .local files in test environment ([#135](https://github.com/railsconfig/config/issues/135), [#233](https://github.com/railsconfig/config/pull/233))
 * Execute default rspec against latest Rails app and load appropriate development dependencies dynamically ([#241](https://github.com/railsconfig/config/pull/241))
 * Fix inconsistent documentation for ENV prefix and default value in generator ([#246](https://github.com/railsconfig/config/pull/246))
+* Get rid of unused Rails Engine class definition ([#247](https://github.com/railsconfig/config/pull/247))
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+
+### Changes
+
+* Get rid of unused Rails Engine class definition ([#247](https://github.com/railsconfig/config/pull/247))
+
 ## 2.1.0
 
 ### New features
@@ -14,7 +19,6 @@
 * Ignore .local files in test environment ([#135](https://github.com/railsconfig/config/issues/135), [#233](https://github.com/railsconfig/config/pull/233))
 * Execute default rspec against latest Rails app and load appropriate development dependencies dynamically ([#241](https://github.com/railsconfig/config/pull/241))
 * Fix inconsistent documentation for ENV prefix and default value in generator ([#246](https://github.com/railsconfig/config/pull/246))
-* Get rid of unused Rails Engine class definition ([#247](https://github.com/railsconfig/config/pull/247))
 
 ### Bug fixes
 

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -3,7 +3,6 @@ require 'config/compatibility'
 require 'config/options'
 require 'config/configuration'
 require 'config/version'
-require 'config/integrations/rails/engine' if defined?(::Rails)
 require 'config/sources/yaml_source'
 require 'config/sources/hash_source'
 require 'config/validation/schema'

--- a/lib/config/integrations/rails/engine.rb
+++ b/lib/config/integrations/rails/engine.rb
@@ -1,9 +1,0 @@
-module Config
-  module Integrations
-    module Rails
-      class Engine < ::Rails::Engine
-        isolate_namespace Config
-      end
-    end
-  end
-end


### PR DESCRIPTION
I found that Config defines an isolated Engine class under Rails environment, but this simple plugin actually does not use Rails Engine feature at all. This plugin already has a Railtie, and that's enough for doing things that this plugin offers.

Creating an unused Engine class like this is not just unnecessary but indeed rather harmful for the users' applications, because it slows down the application initialization process, consumes much memory, and slows down auto/eager loading, request handling, rendering, etc. by adding entries for them.